### PR TITLE
tuning-kms-connections: KMS max concurrency to 100

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -85,7 +85,7 @@ interop-commons {
   isInternetFacing = true
 
   kms {
-    max-concurrency = 1024
+    max-concurrency = 100
     max-concurrency = ${?KMS_MAX_CONCURRENCY}
     max-acquisition-timeout = "10 seconds"
     max-acquisition-timeout = ${?KMS_MAX_ACQUISITION_TIMEOUT}


### PR DESCRIPTION
Load testing shows that the pod is not able to correctly handle 1024 connections.
100 seems a value with reasonable results